### PR TITLE
change to not console request

### DIFF
--- a/src/services/TypesenseService.php
+++ b/src/services/TypesenseService.php
@@ -62,14 +62,14 @@ class TypesenseService extends Component
                     'connection_timeout_seconds' => 2,
                 ]);
             } else {
-                if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+                if (!Craft::$app->getRequest()->getIsConsoleRequest()) {
                     Craft::$app->getSession()->setNotice(Craft::t('typesense', 'Please provide your typesense API key in the settings to get started'));
                 }
 
                 Craft::error(Craft::t('typesense', 'Please provide your typesense API key in the settings to get started'), 'typesense');
             }
         } catch (\Exception $exception) {
-            if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+            if (!Craft::$app->getRequest()->getIsConsoleRequest()) {
                 Craft::$app->getSession()->setNotice(Craft::t('typesense', 'There was an error with the Typesense Client Connection, check the logs'));
             }
 


### PR DESCRIPTION
Fixed so the check is not console request to show the error message on the session, as the session does not exist on the console request.