### PR TITLE
Update schema console command

### DIFF
--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Typesense plugin for Craft CMS 5.x
  *
@@ -307,6 +308,7 @@ class Typesense extends Plugin
             'typesense/save-collection' => 'typesense/collections/save-collection',
             'typesense/sync-collection' => 'typesense/collections/sync-collection',
             'typesense/flush-collection' => 'typesense/collections/flush-collection',
+            'typesense/update-schema' => 'typesense/collections/update-schema',
         ];
     }
 

--- a/src/console/controllers/DefaultController.php
+++ b/src/console/controllers/DefaultController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Typesense plugin for Craft CMS 5.x
  *
@@ -90,6 +91,11 @@ class DefaultController extends Controller
                 ]
             ]));
         }
+    }
+
+    public function actionUpdateSchema()
+    {
+        Typesense::$plugin->getCollections()->updateSchema();
     }
 
     public function actionSync()

--- a/src/services/CollectionService.php
+++ b/src/services/CollectionService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author CraftPulse
  * @since 4.0.0
@@ -9,9 +10,7 @@ namespace percipiolondon\typesense\services;
 use craft\base\MemoizableArray;
 use craft\db\Query;
 use Craft;
-
 use percipiolondon\typesense\models\CollectionModel as Collection;
-
 use percipiolondon\typesense\Typesense;
 use Throwable;
 use yii\base\Component;
@@ -56,7 +55,6 @@ class CollectionService extends Component
         }
     }
 
-
     private function _verifyClient(): bool
     {
         $client = Typesense::$plugin->getClient()->client();
@@ -65,5 +63,34 @@ class CollectionService extends Component
         }
 
         return true;
+    }
+
+    /**
+     * Update the schema in Typesense based on the configuration in PHP
+     *
+     * @return void
+     */
+    public function updateSchema(): void
+    {
+        $indexes = Typesense::$plugin->getSettings()->collections;
+
+        foreach ($indexes as $index) {
+
+            print('Updating schema ' . $index->indexName);
+            print(PHP_EOL);
+
+            $updateSchema = ['fields' => []];
+            foreach ($index->schema['fields'] as $field) {
+                $updateSchema['fields'][] = [
+                    'name' => $field['name'],
+                    'drop' => true
+                ];
+                $updateSchema['fields'][] = $field;
+            }
+            Typesense::$plugin->getClient()->client()->collections[$index->indexName]->update($updateSchema);
+
+            print('Updated schema ' . $index->indexName);
+            print(PHP_EOL);
+        }
     }
 }


### PR DESCRIPTION
This is a PR to add a updateSchema console command.

It's great that this plugin creates a schema if it does not already exist, but, we have found it useful in our own fork to also have the ability to update the schema if we tweak it during development.

This console command allows a developer to drop all fields and completely recreate the schema very quickly and easily.

It is, of course, worth considering renaming this function "destroyAndUpdateSchema" to impress upon the developer that this function is also destructive 🤔