### PR TITLE
Add the ability to delete documents if the .all syntax is used

### DIFF
--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -229,6 +229,12 @@ class DocumentsController extends Controller
                         $collection = CollectionHelper::getCollectionBySection($section);
                     }
 
+                    // get the generic type if specific doesn't exist
+                    if (is_null($collection)) {
+                        $section = $entry->section->handle . '.all';
+                        $collection = CollectionHelper::getCollectionBySection($section);
+                    }
+
                     if ($collection) {
                         $resolver = $collection->schema['resolver']($entry);
                     }


### PR DESCRIPTION
Currently, documents in a collection which is defined with the .all syntax in the controller are never deleted.

This PR fixes that bug