### PR TITLE
Batch document sync jobs

### DIFF
--- a/src/jobs/SyncDocumentsJob.php
+++ b/src/jobs/SyncDocumentsJob.php
@@ -11,13 +11,14 @@
 namespace percipiolondon\typesense\jobs;
 
 use Craft;
-use craft\errors\MissingComponentException;
-use craft\queue\BaseJob;
-
-use Http\Client\Exception;
+use craft\base\Batchable;
+use craft\db\Query;
+use craft\db\QueryBatcher;
+use craft\queue\BaseBatchedJob;
 use percipiolondon\typesense\helpers\CollectionHelper;
 use percipiolondon\typesense\Typesense;
-use Typesense\Exceptions\TypesenseClientError;
+use percipiolondon\typesense\TypesenseCollectionIndex;
+use Typesense\Client as TypesenseClient;
 
 /**
  * TypesenseTask job
@@ -37,7 +38,7 @@ use Typesense\Exceptions\TypesenseClientError;
  * @package   Typesense
  * @since     1.0.0
  */
-class SyncDocumentsJob extends BaseJob
+class SyncDocumentsJob extends BaseBatchedJob
 {
     // Public Properties
     // =========================================================================
@@ -47,77 +48,95 @@ class SyncDocumentsJob extends BaseJob
      */
     public array $criteria = [];
 
-    // Public Methods
+    /**
+     * @var array<string, bool>
+     */
+    public array $staleDocumentIds = [];
+
+    protected ?TypesenseCollectionIndex $collection = null;
+
+    protected ?TypesenseClient $client = null;
+
+    // Protected Methods
     // =========================================================================
 
-    /**
-     * @throws TypesenseClientError
-     * @throws MissingComponentException
-     * @throws Exception
-     */
-    public function execute($queue): void
+    protected function loadData(): Batchable
     {
-        $upsertIds = [];
-        $collection = CollectionHelper::getCollection($this->criteria['index']);
+        $this->collection = CollectionHelper::getCollection($this->criteria['index']);
+        $this->client = Typesense::$plugin->getClient()->client() ?: null;
+
+        if (!$this->client || !$this->collection) {
+            return new QueryBatcher((new Query())->from('{{%elements}}')->where('0=1'));
+        }
+
+        $query = clone $this->collection->criteria;
+
+        return new QueryBatcher($query->orderBy('id ASC'));
+    }
+
+    protected function before(): void
+    {
+        if (!$this->client || !$this->collection) {
+            return;
+        }
+
         $collectionTypesense = Typesense::$plugin->getCollections()->getCollectionByCollectionRetrieve($this->criteria['index']);
-        $client = Typesense::$plugin->getClient()->client();
 
-        if ($client !== false && !is_null($collection)) {
+        if ($collectionTypesense !== [] && ($this->criteria['type'] ?? null) === 'Flush') {
+            $this->client->collections[$this->criteria['index']]->delete();
+            $collectionTypesense = null;
+        }
 
-            // delete collections if the action is flush
-            if ($collectionTypesense !== [] && $this->criteria['type'] === 'Flush') {
-                Typesense::$plugin->getClient()->client()?->collections[$this->criteria['index']]->delete();
-                $collectionTypesense = null;
-            }
+        if (!$collectionTypesense) {
+            $this->client->collections->create($this->collection->schema);
+        }
 
-            //create a new schema if a collection has been flushed
-            if (!$collectionTypesense) {
-                $collectionTypesense = $client->collections->create($collection->schema);
-            }
+        $this->staleDocumentIds = [];
 
-            if ($collectionTypesense !== []) {
-                $entries = $collection->criteria->all();
-                $totalEntries = count($entries);
+        if (($this->criteria['type'] ?? null) === 'Flush') {
+            return;
+        }
 
-                //fetch each document of entry to update
-                foreach ($entries as $i => $entry) {
-
-                    $resolver = $collection->schema['resolver']($entry);
-
-                    if ($resolver) {
-                        $doc = $client->collections[$this->criteria['index']]
-                            ->documents
-                            ->upsert($resolver);
-
-                        $upsertIds[] = $doc['id'];
-                    }
-
-                    $this->setProgress(
-                        $queue,
-                        $i / $totalEntries,
-                        \Craft::t('app', '{step, number} of {total, number}', [
-                            'step' => $i + 1,
-                            'total' => $totalEntries,
-                        ])
-                    );
-                }
-
-
-                // convert documents into an array
-                $documents = CollectionHelper::convertDocumentsToArray($this->criteria['index']);
-
-                // delete documents that aren't existing anymore
-                foreach ($documents as $document) {
-                    if (isset($document['id']) && !in_array($document['id'], $upsertIds)) {
-                        $client->collections[$this->criteria['index']]->documents->delete(['filter_by' => 'id: ' . $document['id']]);
-                    }
-                }
+        foreach (CollectionHelper::convertDocumentsToArray($this->criteria['index']) as $document) {
+            if (isset($document['id'])) {
+                $this->staleDocumentIds[(string)$document['id']] = true;
             }
         }
     }
 
-    // Protected Methods
-    // =========================================================================
+    protected function processItem(mixed $item): void
+    {
+        if (!$this->client || !$this->collection) {
+            return;
+        }
+
+        $resolver = $this->collection->schema['resolver']($item);
+
+        if (!$resolver) {
+            return;
+        }
+
+        $doc = $this->client->collections[$this->criteria['index']]
+            ->documents
+            ->upsert($resolver);
+
+        $id = (string)($doc['id'] ?? $resolver['id'] ?? '');
+
+        if ($id !== '') {
+            unset($this->staleDocumentIds[$id]);
+        }
+    }
+
+    protected function after(): void
+    {
+        if (!$this->client) {
+            return;
+        }
+
+        foreach (array_keys($this->staleDocumentIds) as $id) {
+            $this->client->collections[$this->criteria['index']]->documents->delete(['filter_by' => 'id: ' . $id]);
+        }
+    }
 
     /**
      * Returns a default description for [[getDescription()]], if [[description]] isn’t set.


### PR DESCRIPTION
### Description

Moves document sync onto Craft's batched queue job contract so large indexes can progress across spawned jobs without losing stale-document cleanup state.

Based on https://github.com/craftpulse/craft-typesense/compare/v5...imarc:craft-typesense:v5, but fixing some issues (cc @LinneaImarc)

- It put flush/create side effects in `loadData()`. Since `BaseBatchedJob` reloads data for spawned batches, a flush job could delete/recreate the collection again on later batches.
- It stored processed IDs in protected `$upsertIds`, which won’t survive queue serialization between spawned jobs. That makes stale cleanup only aware of the final batch.
- It didn’t guarantee `loadData()` returns a `Batchable` on missing client/collection paths.
- It batched the original criteria query without cloning or forcing stable ID ordering, which makes offset-based batching more fragile.