### PR TITLE
5.8.4: batched sync, namespace forward-alias, and community fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.8.3 - 2026-03-27
+### Fixed
+- Fixed site-aware collection resolution in `DocumentsController` for multi-instance Cockpit elements. Previously, `handleSave` always resolved to the first matching collection (Go4Jobs), causing FiftyFivePlus jobs and departments to never sync to their correct Typesense index on element save.
+
 ## 5.8.2 - 2025-12-08
 ### Fixed
 - Fixed an where the custom elements wouldn't sync - this is cockpit specific, temporary solution until full rework is labelled "done".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.8.4 - Unreleased
+> ### Heads up: namespace move in 5.9.0
+> In 5.9.0 the internal PHP namespace moves from `percipiolondon\typesense` to `craftpulse\typesense`. The Composer package name (`craftpulse/craft-typesense`) and the plugin handle (`typesense`) do not change, so project config, permissions, and settings are unaffected. The move is bridged in both directions: on this 5.8.x line a forward-compatibility alias lets you reference the future `craftpulse\typesense\*` class names today, and on 5.9.0 a backwards-compatibility alias keeps the `percipiolondon\typesense\*` names working (with a deprecation notice). Update your imports to `craftpulse\typesense\*` before upgrading.
+
+### Added
+- Forward-compatibility alias for the upcoming `craftpulse\typesense` namespace: reference the future class names (for example in `config/typesense.php`) today and they resolve to the current `percipiolondon\typesense\*` classes.
+- Added an `update-schema` console command (`craft typesense/default/update-schema`) that drops and recreates every configured collection's fields from `config/typesense.php`, useful while iterating on a schema in development. It is destructive (existing field data is removed and must be re-synced), so it prints that in `./craft help` and prompts for confirmation unless `--force` is passed. Thanks to [@jamie-s-white](https://github.com/jamie-s-white) (#61).
+
+### Changed
+- Reworked the document sync queue flow onto Craft's batched job contract (`BaseBatchedJob`), so large indexes progress across spawned jobs while stale-document cleanup stays correct across the whole run (flush/create side effects run once, processed IDs survive queue serialization, the batchable query is cloned and stably ordered). Thanks to [@timkelty](https://github.com/timkelty) (#70). Expected to resolve #69.
+
+### Fixed
+- Guard against a `null` entry when applying a draft: the after-restore / after-move handler could pass a query miss straight to `handleSave()` (a non-nullable signature) and throw a TypeError. Reported by [@mikeymeister](https://github.com/mikeymeister) (#67).
+- Delete documents from collections defined with the `.all` section syntax: the delete handler resolved only the specific `section.type` collection, so documents in an `.all` collection were never removed. It now falls back to `section.all`, matching the save path. Thanks to [@jamie-s-white](https://github.com/jamie-s-white) (#64).
+- Do not attach the element sync events until an API key is configured, so saving elements on a fresh, not-yet-configured install no longer errors. Thanks to [@jamie-s-white](https://github.com/jamie-s-white) (#63).
+- Confirmed the control-panel Sync/Flush actions build their URLs with `cpUrl()`, so they respect `CRAFT_BASE_CP_URL` and post to the control-panel domain rather than the front-end site URL (the CORS failure reported when the control panel runs on a separate domain). Reported by [@vardumper](https://github.com/vardumper) (#68).
+
 ## 5.8.3 - 2026-03-27
 ### Fixed
 - Fixed site-aware collection resolution in `DocumentsController` for multi-instance Cockpit elements. Previously, `handleSave` always resolved to the first matching collection (Go4Jobs), causing FiftyFivePlus jobs and departments to never sync to their correct Typesense index on element save.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 5.8.4 - Unreleased
+## 5.8.4 - 2026-08-06
 > ### Heads up: namespace move in 5.9.0
 > In 5.9.0 the internal PHP namespace moves from `percipiolondon\typesense` to `craftpulse\typesense`. The Composer package name (`craftpulse/craft-typesense`) and the plugin handle (`typesense`) do not change, so project config, permissions, and settings are unaffected. The move is bridged in both directions: on this 5.8.x line a forward-compatibility alias lets you reference the future `craftpulse\typesense\*` class names today, and on 5.9.0 a backwards-compatibility alias keeps the `percipiolondon\typesense\*` names working (with a deprecation notice). Update your imports to `craftpulse\typesense\*` before upgrading.
 
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - Guard against a `null` entry when applying a draft: the after-restore / after-move handler could pass a query miss straight to `handleSave()` (a non-nullable signature) and throw a TypeError. Reported by [@mikeymeister](https://github.com/mikeymeister) (#67).
 - Delete documents from collections defined with the `.all` section syntax: the delete handler resolved only the specific `section.type` collection, so documents in an `.all` collection were never removed. It now falls back to `section.all`, matching the save path. Thanks to [@jamie-s-white](https://github.com/jamie-s-white) (#64).
+- Fixed a bug where deleting a Cockpit element left its document in the index: the delete handler looked the element up with a `craft\elements\Entry` query, which never matches `craftpulse\cockpit\elements\Job`, `craftpulse\cockpit\elements\Department`, `craftpulse\cockpit\elements\Contact` or `craftpulse\cockpit\elements\MatchFieldEntry`, so those documents were only ever removed by a later full sync.
+- Fixed a bug where deleting a disabled element left its document in the index, because the delete handler's element lookup applied the default enabled-only status filter.
+- Fixed a bug where deleting a Cockpit element did not resolve the site-aware collection, so a FiftyFivePlus job or department would have been removed from the Go4Jobs collection rather than its own. The save and delete handlers now share one collection resolver.
 - Do not attach the element sync events until an API key is configured, so saving elements on a fresh, not-yet-configured install no longer errors. Thanks to [@jamie-s-white](https://github.com/jamie-s-white) (#63).
 - Confirmed the control-panel Sync/Flush actions build their URLs with `cpUrl()`, so they respect `CRAFT_BASE_CP_URL` and post to the control-panel domain rather than the front-end site URL (the CORS failure reported when the control panel runs on a separate domain). Reported by [@vardumper](https://github.com/vardumper) (#68).
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Craft Plugin that synchronises with Typesense.
 
 This plugin requires Craft CMS 5.0.0 or later.
 
+## Upcoming namespace change (5.9.0)
+
+In 5.9.0 the plugin's internal PHP namespace moves from `percipiolondon\typesense`
+to `craftpulse\typesense`. The Composer package name (`craftpulse/craft-typesense`)
+and the plugin handle (`typesense`) do not change, so project config, permissions,
+and settings are unaffected.
+
+The move is bridged in both directions so you can migrate on your own schedule:
+
+- On this 5.8.x line, a forward-compatibility alias lets you reference the future
+  `craftpulse\typesense\*` class names today (for example in `config/typesense.php`
+  or your own code). They resolve to the existing `percipiolondon\typesense\*`
+  classes.
+- On the 5.9.0 line, a backwards-compatibility alias keeps the old
+  `percipiolondon\typesense\*` class names working (with a deprecation notice).
+
+If you reference plugin classes directly, update your imports to
+`craftpulse\typesense\*` before upgrading to 5.9.0.
+
 ## Installation
 
 To install the plugin, follow these instructions.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftpulse/craft-typesense",
     "description": "Craft Plugin that synchronises with Typesense",
     "type": "craft-plugin",
-    "version": "5.8.2",
+    "version": "5.8.3",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftpulse/craft-typesense",
     "description": "Craft Plugin that synchronises with Typesense",
     "type": "craft-plugin",
-    "version": "5.8.3",
+    "version": "5.8.4",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,10 @@
     "autoload": {
         "psr-4": {
             "percipiolondon\\typesense\\": "src/"
-        }
+        },
+        "files": [
+            "src/bootstrap.php"
+        ]
     },
     "scripts": {
         "phpstan": "phpstan --memory-limit=1G"

--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Typesense plugin for Craft CMS 5.x
  *
@@ -308,6 +309,7 @@ class Typesense extends Plugin
             'typesense/save-collection' => 'typesense/collections/save-collection',
             'typesense/sync-collection' => 'typesense/collections/sync-collection',
             'typesense/flush-collection' => 'typesense/collections/flush-collection',
+            'typesense/update-schema' => 'typesense/collections/update-schema',
         ];
     }
 

--- a/src/Typesense.php
+++ b/src/Typesense.php
@@ -309,7 +309,6 @@ class Typesense extends Plugin
             'typesense/save-collection' => 'typesense/collections/save-collection',
             'typesense/sync-collection' => 'typesense/collections/sync-collection',
             'typesense/flush-collection' => 'typesense/collections/flush-collection',
-            'typesense/update-schema' => 'typesense/collections/update-schema',
         ];
     }
 

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Typesense plugin for Craft CMS 5.x
+ *
+ * Forward-compatibility shim for the 5.9.0 PHP namespace move.
+ *
+ * The plugin's internal namespace becomes `craftpulse\typesense` in 5.9.0 (the
+ * Composer package name `craftpulse/craft-typesense` and the plugin handle
+ * `typesense` are unchanged). On this 5.8.x line the classes still live under
+ * `percipiolondon\typesense`, so this file registers a fallback autoloader that
+ * transparently aliases any `craftpulse\typesense\*` class, interface, or trait to
+ * its existing `percipiolondon\typesense\*` counterpart. That lets integrators
+ * migrate their imports and `config/typesense.php` references to the future
+ * `craftpulse\typesense` names today, before upgrading to 5.9.0, and keep working
+ * on 5.8.x in the meantime.
+ *
+ * The autoloader is appended (not prepended), so it only runs after Composer's
+ * PSR-4 autoloader fails to resolve the (not-yet-existing) `craftpulse\typesense`
+ * class. It does not log a deprecation: on this line the `craftpulse\typesense`
+ * names are the forward target, not deprecated, and the `percipiolondon\typesense`
+ * names remain fully supported until 5.9.0.
+ *
+ * @link      https://craft-pulse.com
+ * @copyright Copyright (c) 2025 CraftPulse
+ */
+
+spl_autoload_register(static function(string $class): void {
+    $futurePrefix = 'craftpulse\\typesense\\';
+
+    if (!str_starts_with($class, $futurePrefix)) {
+        return;
+    }
+
+    $target = 'percipiolondon\\typesense\\' . substr($class, strlen($futurePrefix));
+
+    if (!class_exists($target) && !interface_exists($target) && !trait_exists($target)) {
+        return;
+    }
+
+    class_alias($target, $class);
+});

--- a/src/console/controllers/DefaultController.php
+++ b/src/console/controllers/DefaultController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Typesense plugin for Craft CMS 5.x
  *
@@ -90,6 +91,11 @@ class DefaultController extends Controller
                 ]
             ]));
         }
+    }
+
+    public function actionUpdateSchema()
+    {
+        Typesense::$plugin->getCollections()->updateSchema();
     }
 
     public function actionSync()

--- a/src/console/controllers/DefaultController.php
+++ b/src/console/controllers/DefaultController.php
@@ -19,6 +19,7 @@ use percipiolondon\typesense\events\DocumentEvent;
 
 use percipiolondon\typesense\Typesense;
 use yii\console\Controller;
+use yii\console\ExitCode;
 
 /**
  * Default Command
@@ -56,8 +57,31 @@ class DefaultController extends Controller
     public const EVENT_BEFORE_FLUSH = 'beforeFlush';
     public const EVENT_BEFORE_SYNC = 'beforeSync';
 
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * @var bool Whether to skip the confirmation prompt on the destructive
+     * update-schema action.
+     */
+    public bool $force = false;
+
     // Public Methods
     // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+
+        if ($actionID === 'update-schema') {
+            $options[] = 'force';
+        }
+
+        return $options;
+    }
 
     /**
      * Handle typesense/default console commands
@@ -93,9 +117,26 @@ class DefaultController extends Controller
         }
     }
 
+    /**
+     * DESTRUCTIVE: drops and recreates every configured collection's fields.
+     *
+     * Rebuilds each collection's schema by dropping all of its fields and
+     * re-adding them from config/typesense.php. Existing field data is removed
+     * and must be re-synced afterwards. Intended for development when a schema is
+     * tweaked. Prompts for confirmation unless --force is passed.
+     *
+     * @return mixed
+     */
     public function actionUpdateSchema()
     {
+        if (!$this->force && !$this->confirm('This DROPS and recreates the fields on every configured collection, removing existing field data. Continue?')) {
+            $this->stdout('Aborted.' . PHP_EOL);
+            return ExitCode::OK;
+        }
+
         Typesense::$plugin->getCollections()->updateSchema();
+
+        return ExitCode::OK;
     }
 
     public function actionSync()

--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -185,24 +185,28 @@ class DocumentsController extends Controller
             }
         }
 
-        // Temporary until full Typesense Rework to support Cockpit.
-        if($entry instanceof Job) {
-            $collection = CollectionHelper::getCollectionBySection('jobs.all');
+        // Resolve the correct Typesense collection based on the element's site.
+        if ($entry instanceof Job) {
+            $siteHandle = $entry->getSite()->handle;
+            $sectionKey = $siteHandle === 'fiftyfiveplus' ? 'jobs.ffp' : 'jobs.all';
+            $collection = CollectionHelper::getCollectionBySection($sectionKey);
 
             // Create collection if it doesn't exist
             if (!$collection instanceof \percipiolondon\typesense\TypesenseCollectionIndex) {
                 Typesense::$plugin->getCollections()->saveCollections();
-                $collection = CollectionHelper::getCollectionBySection('jobs.all');
+                $collection = CollectionHelper::getCollectionBySection($sectionKey);
             }
         }
 
-        if($entry instanceof Department) {
-            $collection = CollectionHelper::getCollectionBySection('offices');
+        if ($entry instanceof Department) {
+            $siteHandle = $entry->getSite()->handle;
+            $sectionKey = $siteHandle === 'fiftyfiveplus' ? 'offices.ffp' : 'offices.all';
+            $collection = CollectionHelper::getCollectionBySection($sectionKey);
 
             // Create collection if it doesn't exist
             if (!$collection instanceof \percipiolondon\typesense\TypesenseCollectionIndex) {
                 Typesense::$plugin->getCollections()->saveCollections();
-                $collection = CollectionHelper::getCollectionBySection('offices');
+                $collection = CollectionHelper::getCollectionBySection($sectionKey);
             }
         }
 

--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace percipiolondon\typesense\controllers;
 
 use Craft;
+use craft\helpers\App;
 use craft\services\Structures;
 use craft\web\Controller;
 use craft\elements\Entry;
@@ -39,69 +41,69 @@ class DocumentsController extends Controller
     {
         parent::init();
 
-        /* SAVE EVENTS */
-        $events = [
-            [Elements::class, Elements::EVENT_AFTER_SAVE_ELEMENT],
-            [Elements::class, Elements::EVENT_AFTER_RESTORE_ELEMENT],
-            [Elements::class, Elements::EVENT_AFTER_UPDATE_SLUG_AND_URI],
-            [Structures::class, Structures::EVENT_AFTER_MOVE_ELEMENT],
-        ];
+        // Only attach events to elements if the API key is configured
+        if (!is_null(App::parseEnv(Typesense::$plugin->getSettings()->apiKey))) {
+            /* SAVE EVENTS */
+            $events = [
+                [Elements::class, Elements::EVENT_AFTER_SAVE_ELEMENT],
+                [Elements::class, Elements::EVENT_AFTER_RESTORE_ELEMENT],
+                [Elements::class, Elements::EVENT_AFTER_UPDATE_SLUG_AND_URI],
+                [Structures::class, Structures::EVENT_AFTER_MOVE_ELEMENT],
+            ];
 
-        foreach ($events as $event) {
-            Event::on(
-                $event[0],
-                $event[1],
-                function (ElementEvent $event) {
-                    // We need to allow for our cockpit plugin Elements here.
-                    // Check if class exists
+            foreach ($events as $event) {
+                Event::on(
+                    $event[0],
+                    $event[1],
+                    function (ElementEvent $event) {
+                        // We need to allow for our cockpit plugin Elements here.
+                        // Check if class exists
+                        if (class_exists(Cockpit::class)) {
+                            // This allowedTypes thing is wonderful! ;)
+                            $allowedTypes = [Entry::class, Job::class, Department::class, MatchFieldEntry::class, Contact::class];
 
+                            if (!in_array(get_class($event->element), $allowedTypes)) {
+                                return;
+                            }
+                        } else {
+                            // Ignore any element that is not an entry
+                            if (!($event->element instanceof Entry)) {
+                                return;
+                            }
+                        }
 
+                        $element = $event->element;
 
-                   if (class_exists(Cockpit::class)) {
-                        // This allowedTypes thing is wonderful! ;)
-                        $allowedTypes = [Entry::class, Job::class, Department::class, MatchFieldEntry::class, Contact::class];
-
-                        if (!in_array(get_class($event->element), $allowedTypes)) {
+                        if (ElementHelper::isDraftOrRevision($element)) {
+                            // don’t do anything with drafts or revisions
                             return;
                         }
-                    } else {
-                        // Ignore any element that is not an entry
-                        if (!($event->element instanceof Entry)) {
-                            return;
-                        }
-                    }
 
-                    $element = $event->element;
+                        $this->handleSave($element);
 
-                    if (ElementHelper::isDraftOrRevision($element)) {
-                        // don’t do anything with drafts or revisions
-                        return;
-                    }
-
-                    $this->handleSave($element);
-
-                    if ($event->name === Elements::EVENT_AFTER_RESTORE_ELEMENT || $event->name === Structures::EVENT_AFTER_MOVE_ELEMENT) {
-                        foreach($element->getSupportedSites() as $site) {
-                            if ($site['siteId'] ?? null) {
-                                $entry = Entry::find()->id($element->id)->siteId($site['siteId'])->one();
-                                if ($entry) {
-                                    $this->handleSave($entry);
+                        if ($event->name === Elements::EVENT_AFTER_RESTORE_ELEMENT || $event->name === Structures::EVENT_AFTER_MOVE_ELEMENT) {
+                            foreach ($element->getSupportedSites() as $site) {
+                                if ($site['siteId'] ?? null) {
+                                    $entry = Entry::find()->id($element->id)->siteId($site['siteId'])->one();
+                                    if ($entry) {
+                                        $this->handleSave($entry);
+                                    }
                                 }
                             }
                         }
                     }
+                );
+            }
+
+            /* DELETE EVENT */
+            Event::on(
+                Elements::class,
+                Elements::EVENT_BEFORE_DELETE_ELEMENT,
+                function (ElementEvent $event) {
+                    $this->handleDelete($event);
                 }
             );
         }
-
-        /* DELETE EVENT */
-        Event::on(
-            Elements::class,
-            Elements::EVENT_BEFORE_DELETE_ELEMENT,
-            function (ElementEvent $event) {
-                $this->handleDelete($event);
-            }
-        );
     }
 
     public function triggerAfterDelete(string $index, string $id): void
@@ -212,7 +214,9 @@ class DocumentsController extends Controller
             }
         }
 
-        if (is_null($collection)) return;
+        if (is_null($collection)) {
+            return;
+        }
 
         $resolver = $collection->schema['resolver']($entry);
 

--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -281,6 +281,12 @@ class DocumentsController extends Controller
                         $collection = CollectionHelper::getCollectionBySection($section);
                     }
 
+                    // get the generic type if specific doesn't exist
+                    if (is_null($collection)) {
+                        $section = $entry->section->handle . '.all';
+                        $collection = CollectionHelper::getCollectionBySection($section);
+                    }
+
                     if ($collection) {
                         $resolver = $collection->schema['resolver']($entry);
                     }

--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -3,6 +3,7 @@
 namespace percipiolondon\typesense\controllers;
 
 use Craft;
+use craft\base\ElementInterface;
 use craft\helpers\App;
 use craft\services\Structures;
 use craft\web\Controller;
@@ -12,6 +13,7 @@ use craft\events\ElementEvent;
 use craft\services\Elements;
 use percipiolondon\typesense\events\DocumentEvent;
 use percipiolondon\typesense\helpers\CollectionHelper;
+use percipiolondon\typesense\TypesenseCollectionIndex;
 use percipiolondon\typesense\Typesense;
 
 use craftpulse\cockpit\Cockpit;
@@ -162,57 +164,7 @@ class DocumentsController extends Controller
 
     protected function handleSave(Entry|Job|MatchFieldEntry|Department|Contact $entry): void
     {
-        $sectionHandle = $entry->section->handle ?? null;
-        $type = $entry->type->handle ?? null;
-        $collection = null;
-
-        /* This is very limited - as we always need to have a section named the same, this should go to settings, and mappable!) */
-        if ($sectionHandle) {
-            $section = '';
-
-            if ($type) {
-                $section = $sectionHandle . '.' . $type;
-            }
-
-            $collection = CollectionHelper::getCollectionBySection($section);
-
-            // Get the generic type if specific doesn't exist
-            if (is_null($collection)) {
-                $section = $sectionHandle . '.all';
-                $collection = CollectionHelper::getCollectionBySection($section);
-            }
-
-            // Create collection if it doesn't exist
-            if (!$collection instanceof \percipiolondon\typesense\TypesenseCollectionIndex) {
-                Typesense::$plugin->getCollections()->saveCollections();
-                $collection = CollectionHelper::getCollectionBySection($section);
-            }
-        }
-
-        // Resolve the correct Typesense collection based on the element's site.
-        if ($entry instanceof Job) {
-            $siteHandle = $entry->getSite()->handle;
-            $sectionKey = $siteHandle === 'fiftyfiveplus' ? 'jobs.ffp' : 'jobs.all';
-            $collection = CollectionHelper::getCollectionBySection($sectionKey);
-
-            // Create collection if it doesn't exist
-            if (!$collection instanceof \percipiolondon\typesense\TypesenseCollectionIndex) {
-                Typesense::$plugin->getCollections()->saveCollections();
-                $collection = CollectionHelper::getCollectionBySection($sectionKey);
-            }
-        }
-
-        if ($entry instanceof Department) {
-            $siteHandle = $entry->getSite()->handle;
-            $sectionKey = $siteHandle === 'fiftyfiveplus' ? 'offices.ffp' : 'offices.all';
-            $collection = CollectionHelper::getCollectionBySection($sectionKey);
-
-            // Create collection if it doesn't exist
-            if (!$collection instanceof \percipiolondon\typesense\TypesenseCollectionIndex) {
-                Typesense::$plugin->getCollections()->saveCollections();
-                $collection = CollectionHelper::getCollectionBySection($sectionKey);
-            }
-        }
+        $collection = $this->resolveCollection($entry);
 
         if (is_null($collection)) {
             return;
@@ -253,7 +205,7 @@ class DocumentsController extends Controller
         }
     }
 
-    protected function handleDelete(ElementEvent $event)
+    protected function handleDelete(ElementEvent $event): void
     {
         $element = $event->element;
 
@@ -262,47 +214,108 @@ class DocumentsController extends Controller
             return;
         }
 
+        $elementsService = Craft::$app->getElements();
+
         foreach ($element->getSupportedSites() as $site) {
-            if ($site['siteId'] ?? null) {
+            $siteId = $site['siteId'] ?? null;
 
-                $entry = Entry::find()->id($element->id)->siteId($site['siteId'])->one();
+            if (!$siteId) {
+                continue;
+            }
 
-                if ($entry) {
-                    $section = $entry->section->handle ?? null;
-                    $type = $entry->type->handle ?? null;
-                    $collection = null;
-                    $resolver = null;
+            // Re-fetch as the element's own type. Querying Entry::find() here meant
+            // Cockpit's Job, Department, Contact and MatchFieldEntry elements never
+            // resolved, so their documents were left behind on delete. getElementById()
+            // also ignores status, so disabled elements resolve too.
+            $source = $elementsService->getElementById($element->id, get_class($element), $siteId);
 
-                    if ($section) {
-                        if ($type) {
-                            $section = $section . '.' . $type;
-                        }
+            if (!$source) {
+                continue;
+            }
 
-                        $collection = CollectionHelper::getCollectionBySection($section);
-                    }
+            $collection = $this->resolveCollection($source);
 
-                    // get the generic type if specific doesn't exist
-                    if (is_null($collection)) {
-                        $section = $entry->section->handle . '.all';
-                        $collection = CollectionHelper::getCollectionBySection($section);
-                    }
+            if (is_null($collection)) {
+                continue;
+            }
 
-                    if ($collection) {
-                        $resolver = $collection->schema['resolver']($entry);
-                    }
+            $resolver = $collection->schema['resolver']($source);
 
-                    if ($resolver) {
-                        // Trigger the before delete event
-                        $this->triggerBeforeDelete($collection->indexName, $resolver['id']);
+            if (!$resolver) {
+                continue;
+            }
 
-                        Craft::info('Typesense delete document based on: ' . $entry->title . ' - ' . $entry->getSite()->handle, __METHOD__);
-                        Typesense::$plugin->getClient()->client()->collections[$collection->indexName]->documents->delete(['filter_by' => 'id: ' . $resolver['id']]);
+            // Trigger the before delete event
+            $this->triggerBeforeDelete($collection->indexName, $resolver['id']);
 
-                        // Trigger the after delete event
-                        $this->triggerAfterDelete($collection->indexName, $resolver['id']);
-                    }
-                }
+            Craft::info('Typesense delete document based on: ' . $source->title . ' - ' . $source->getSite()->handle, __METHOD__);
+            Typesense::$plugin->getClient()->client()->collections[$collection->indexName]->documents->delete(['filter_by' => 'id: ' . $resolver['id']]);
+
+            // Trigger the after delete event
+            $this->triggerAfterDelete($collection->indexName, $resolver['id']);
+        }
+    }
+
+    /**
+     * Resolves the Typesense collection an element belongs to.
+     *
+     * Shared by the save and delete handlers so the two cannot drift apart: the
+     * delete path previously carried its own copy of this logic and missed both
+     * the site-aware Cockpit collections and the `.all` fallback.
+     *
+     * @param ElementInterface $element
+     * @return \percipiolondon\typesense\TypesenseCollectionIndex|null
+     */
+    protected function resolveCollection(ElementInterface $element): ?TypesenseCollectionIndex
+    {
+        // Cockpit elements are site-scoped: each instance indexes into its own
+        // collection, so these resolve from the element's site rather than a section.
+        if ($element instanceof Job) {
+            return $this->collectionBySection($element->getSite()->handle === 'fiftyfiveplus' ? 'jobs.ffp' : 'jobs.all');
+        }
+
+        if ($element instanceof Department) {
+            return $this->collectionBySection($element->getSite()->handle === 'fiftyfiveplus' ? 'offices.ffp' : 'offices.all');
+        }
+
+        /* This is very limited - as we always need to have a section named the same, this should go to settings, and mappable!) */
+        $sectionHandle = $element->section->handle ?? null;
+
+        if (!$sectionHandle) {
+            return null;
+        }
+
+        $type = $element->type->handle ?? null;
+
+        if ($type) {
+            $collection = CollectionHelper::getCollectionBySection($sectionHandle . '.' . $type);
+
+            if ($collection instanceof TypesenseCollectionIndex) {
+                return $collection;
             }
         }
+
+        // Get the generic type if specific doesn't exist
+        return $this->collectionBySection($sectionHandle . '.all');
+    }
+
+    /**
+     * Returns the collection registered for a `section.type` key, creating the
+     * configured collections first if it isn't registered yet.
+     *
+     * @param string $section
+     * @return \percipiolondon\typesense\TypesenseCollectionIndex|null
+     */
+    protected function collectionBySection(string $section): ?TypesenseCollectionIndex
+    {
+        $collection = CollectionHelper::getCollectionBySection($section);
+
+        // Create collection if it doesn't exist
+        if (!$collection instanceof TypesenseCollectionIndex) {
+            Typesense::$plugin->getCollections()->saveCollections();
+            $collection = CollectionHelper::getCollectionBySection($section);
+        }
+
+        return $collection instanceof TypesenseCollectionIndex ? $collection : null;
     }
 }

--- a/src/controllers/DocumentsController.php
+++ b/src/controllers/DocumentsController.php
@@ -84,7 +84,9 @@ class DocumentsController extends Controller
                         foreach($element->getSupportedSites() as $site) {
                             if ($site['siteId'] ?? null) {
                                 $entry = Entry::find()->id($element->id)->siteId($site['siteId'])->one();
-                                $this->handleSave($entry);
+                                if ($entry) {
+                                    $this->handleSave($entry);
+                                }
                             }
                         }
                     }

--- a/src/jobs/SyncDocumentsJob.php
+++ b/src/jobs/SyncDocumentsJob.php
@@ -11,13 +11,14 @@
 namespace percipiolondon\typesense\jobs;
 
 use Craft;
-use craft\errors\MissingComponentException;
-use craft\queue\BaseJob;
-
-use Http\Client\Exception;
+use craft\base\Batchable;
+use craft\db\Query;
+use craft\db\QueryBatcher;
+use craft\queue\BaseBatchedJob;
 use percipiolondon\typesense\helpers\CollectionHelper;
 use percipiolondon\typesense\Typesense;
-use Typesense\Exceptions\TypesenseClientError;
+use percipiolondon\typesense\TypesenseCollectionIndex;
+use Typesense\Client as TypesenseClient;
 
 /**
  * TypesenseTask job
@@ -37,7 +38,7 @@ use Typesense\Exceptions\TypesenseClientError;
  * @package   Typesense
  * @since     1.0.0
  */
-class SyncDocumentsJob extends BaseJob
+class SyncDocumentsJob extends BaseBatchedJob
 {
     // Public Properties
     // =========================================================================
@@ -47,77 +48,95 @@ class SyncDocumentsJob extends BaseJob
      */
     public array $criteria = [];
 
-    // Public Methods
+    /**
+     * @var array<string, bool>
+     */
+    public array $staleDocumentIds = [];
+
+    protected ?TypesenseCollectionIndex $collection = null;
+
+    protected ?TypesenseClient $client = null;
+
+    // Protected Methods
     // =========================================================================
 
-    /**
-     * @throws TypesenseClientError
-     * @throws MissingComponentException
-     * @throws Exception
-     */
-    public function execute($queue): void
+    protected function loadData(): Batchable
     {
-        $upsertIds = [];
-        $collection = CollectionHelper::getCollection($this->criteria['index']);
+        $this->collection = CollectionHelper::getCollection($this->criteria['index']);
+        $this->client = Typesense::$plugin->getClient()->client() ?: null;
+
+        if (!$this->client || !$this->collection) {
+            return new QueryBatcher((new Query())->from('{{%elements}}')->where('0=1'));
+        }
+
+        $query = clone $this->collection->criteria;
+
+        return new QueryBatcher($query->orderBy('id ASC'));
+    }
+
+    protected function before(): void
+    {
+        if (!$this->client || !$this->collection) {
+            return;
+        }
+
         $collectionTypesense = Typesense::$plugin->getCollections()->getCollectionByCollectionRetrieve($this->criteria['index']);
-        $client = Typesense::$plugin->getClient()->client();
 
-        if ($client !== false && !is_null($collection)) {
+        if ($collectionTypesense !== [] && ($this->criteria['type'] ?? null) === 'Flush') {
+            $this->client->collections[$this->criteria['index']]->delete();
+            $collectionTypesense = null;
+        }
 
-            // delete collections if the action is flush
-            if ($collectionTypesense !== [] && $this->criteria['type'] === 'Flush') {
-                Typesense::$plugin->getClient()->client()?->collections[$this->criteria['index']]->delete();
-                $collectionTypesense = null;
-            }
+        if (!$collectionTypesense) {
+            $this->client->collections->create($this->collection->schema);
+        }
 
-            //create a new schema if a collection has been flushed
-            if (!$collectionTypesense) {
-                $collectionTypesense = $client->collections->create($collection->schema);
-            }
+        $this->staleDocumentIds = [];
 
-            if ($collectionTypesense !== []) {
-                $entries = $collection->criteria->all();
-                $totalEntries = count($entries);
+        if (($this->criteria['type'] ?? null) === 'Flush') {
+            return;
+        }
 
-                //fetch each document of entry to update
-                foreach ($entries as $i => $entry) {
-
-                    $resolver = $collection->schema['resolver']($entry);
-
-                    if ($resolver) {
-                        $doc = $client->collections[$this->criteria['index']]
-                            ->documents
-                            ->upsert($resolver);
-
-                        $upsertIds[] = $doc['id'];
-                    }
-
-                    $this->setProgress(
-                        $queue,
-                        $i / $totalEntries,
-                        \Craft::t('app', '{step, number} of {total, number}', [
-                            'step' => $i + 1,
-                            'total' => $totalEntries,
-                        ])
-                    );
-                }
-
-
-                // convert documents into an array
-                $documents = CollectionHelper::convertDocumentsToArray($this->criteria['index']);
-
-                // delete documents that aren't existing anymore
-                foreach ($documents as $document) {
-                    if (isset($document['id']) && !in_array($document['id'], $upsertIds)) {
-                        $client->collections[$this->criteria['index']]->documents->delete(['filter_by' => 'id: ' . $document['id']]);
-                    }
-                }
+        foreach (CollectionHelper::convertDocumentsToArray($this->criteria['index']) as $document) {
+            if (isset($document['id'])) {
+                $this->staleDocumentIds[(string)$document['id']] = true;
             }
         }
     }
 
-    // Protected Methods
-    // =========================================================================
+    protected function processItem(mixed $item): void
+    {
+        if (!$this->client || !$this->collection) {
+            return;
+        }
+
+        $resolver = $this->collection->schema['resolver']($item);
+
+        if (!$resolver) {
+            return;
+        }
+
+        $doc = $this->client->collections[$this->criteria['index']]
+            ->documents
+            ->upsert($resolver);
+
+        $id = (string)($doc['id'] ?? $resolver['id'] ?? '');
+
+        if ($id !== '') {
+            unset($this->staleDocumentIds[$id]);
+        }
+    }
+
+    protected function after(): void
+    {
+        if (!$this->client) {
+            return;
+        }
+
+        foreach (array_keys($this->staleDocumentIds) as $id) {
+            $this->client->collections[$this->criteria['index']]->documents->delete(['filter_by' => 'id: ' . $id]);
+        }
+    }
 
     /**
      * Returns a default description for [[getDescription()]], if [[description]] isn’t set.

--- a/src/services/CollectionService.php
+++ b/src/services/CollectionService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author CraftPulse
  * @since 4.0.0
@@ -13,7 +14,6 @@ use Craft;
 use craft\errors\MissingComponentException;
 use Http\Client\Exception;
 use percipiolondon\typesense\models\CollectionModel as Collection;
-
 use percipiolondon\typesense\Typesense;
 use Throwable;
 use Typesense\Exceptions\TypesenseClientError;
@@ -64,7 +64,6 @@ class CollectionService extends Component
         }
     }
 
-
     private function _verifyClient(): bool
     {
         $client = Typesense::$plugin->getClient()->client();
@@ -73,5 +72,34 @@ class CollectionService extends Component
         }
 
         return true;
+    }
+
+    /**
+     * Update the schema in Typesense based on the configuration in PHP
+     *
+     * @return void
+     */
+    public function updateSchema(): void
+    {
+        $indexes = Typesense::$plugin->getSettings()->collections;
+
+        foreach ($indexes as $index) {
+
+            print('Updating schema ' . $index->indexName);
+            print(PHP_EOL);
+
+            $updateSchema = ['fields' => []];
+            foreach ($index->schema['fields'] as $field) {
+                $updateSchema['fields'][] = [
+                    'name' => $field['name'],
+                    'drop' => true
+                ];
+                $updateSchema['fields'][] = $field;
+            }
+            Typesense::$plugin->getClient()->client()->collections[$index->indexName]->update($updateSchema);
+
+            print('Updated schema ' . $index->indexName);
+            print(PHP_EOL);
+        }
     }
 }


### PR DESCRIPTION
> Based on the 5.8.3 tag (which sits ahead of `v5`); fast-forward `v5` to 5.8.3 before merging so the site-aware Cockpit collection fix is retained.

Backport round for 5.8.4 on the 5.8.x (`v5`) line. Reviewed and cherry-picked with original authorship where the change came from a contributor PR; adapted or fixed on top where noted.

## Namespace
- **Forward-compatibility alias for the 5.9.0 `craftpulse\typesense` namespace.** A Composer `files`-autoload shim aliases `craftpulse\typesense\*` to the current `percipiolondon\typesense\*`, so integrators can migrate their imports and `config/typesense.php` references now and stay working on 5.8.x. No deprecation is logged on this line (the craftpulse names are the forward target). README + CHANGELOG document the two-way alias guarantee.

## Queue
- **Batched document sync (#70, @timkelty).** Moves sync onto `BaseBatchedJob`. Reviewed against the author's four stated failure modes and confirmed each holds: flush/create side effects run once in `before()` (not per reloaded batch), processed IDs live in a public property that survives queue serialization across spawned jobs, `loadData()` returns an empty `Batchable` on missing client/collection, and the query is cloned and stably ordered by id. Expected to resolve #69.

## Fixes
- **Events only bind when an API key is set (#63, @jamie-s-white).** Avoids a save-time error on a fresh install. Adapted on merge: the guard now wraps the current cockpit-aware element filtering (which postdates the PR) and keeps the null-entry guard, rather than the PR's plain `instanceof Entry` check which would have regressed cockpit element support.
- **Delete documents in `.all` collections (#64, @jamie-s-white).** The delete handler now falls back to the `section.all` collection, matching the save path, so documents in an `.all`-defined collection are removed.
- **`update-schema` console command (#61, @jamie-s-white).** Drops and recreates each configured collection's fields from config. Follow-up commit makes the destructive behavior explicit (help text + a confirmation prompt, `--force` to skip) per the author's own suggestion, and removes a dead CP URL rule the PR added (it pointed at a non-existent web action; the feature is console-only).
- **Null-entry guard when applying a draft (#67, reported by @mikeymeister).** The after-restore / after-move handler could pass a query miss to a non-nullable `handleSave()` and throw. Guarded, matching the sibling delete path.
- **Control-panel action URLs / `CRAFT_BASE_CP_URL` (#68, reported by @vardumper).** Confirmed the Sync/Flush actions build URLs with `cpUrl()`, so they respect `CRAFT_BASE_CP_URL` and post to the control-panel domain (resolving the reported CORS failure when the CP is on a separate domain). Already correct on this line; verified and credited.

## Not included
- **#62 ("multiple" label):** skipped. Its `is_array($index->section)` label logic assumes an array `section` config (a fork convention); stock v5 uses a string section, so the label would never show. It also conflicts with #70 on `SyncDocumentsJob`, and its only stock-applicable morsel (an "Unkown" -> "Unknown" typo) is already superseded by the #70 rework.
- **#66:** excluded by decision.

## Verification
The 5.8.x line has no Pest suite. Verified: `composer install` in the branch, `php -l` on every changed file, and a line-by-line review of each cherry-pick against this codebase's actual call sites and conventions (old `percipiolondon` namespace, old code style). The batched-sync serialization behavior was verified against Craft's `BaseBatchedJob`/`__sleep` source; the forward alias was verified resolving at runtime.

No release tag is included.